### PR TITLE
Tweak default browser console styling; reduce allocations in output template rendering

### DIFF
--- a/example/ExampleClient/Program.cs
+++ b/example/ExampleClient/Program.cs
@@ -16,7 +16,7 @@ namespace ExampleClient
 
             Log.Logger = new LoggerConfiguration()
                 .MinimumLevel.Debug()
-                .WriteTo.BrowserConsole(outputTemplate:"[{Timestamp:yyyy-MM-dd HH:mm:ss}@{Level:u3}] Hello from serilog browser console sink! {NewLine}{Message}{NewLine}{Exception}")
+                .WriteTo.BrowserConsole()
                 .CreateLogger();
 
             Log.Debug("Hello, browser!");
@@ -28,7 +28,7 @@ namespace ExampleClient
 
 				builder.RootComponents.Add<App>("app");
 
-				builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+				builder.Services.AddScoped(_ => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 
 				await builder.Build().RunAsync();
             }

--- a/src/Serilog.Sinks.BrowserConsole/LoggerConfigurationBrowserConsoleExtensions.cs
+++ b/src/Serilog.Sinks.BrowserConsole/LoggerConfigurationBrowserConsoleExtensions.cs
@@ -27,7 +27,11 @@ namespace Serilog
     /// </summary>
     public static class LoggerConfigurationBrowserConsoleExtensions
     {
-        private const string DefaultConsoleOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}";
+        const string SerilogToken =
+            "%cserilog{_}color:white;background:#8c7574;border-radius:3px;padding:1px 2px;font-weight:600;";
+            
+        const string DefaultConsoleOutputTemplate = SerilogToken + "{Message}{NewLine}{Exception}";
+        
         /// <summary>
         /// Writes log events to the browser console.
         /// </summary>

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/BrowserConsoleSink.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/BrowserConsoleSink.cs
@@ -20,10 +20,10 @@ using Serilog.Sinks.BrowserConsole.Output;
 
 namespace Serilog.Sinks.BrowserConsole
 {
-    internal class BrowserConsoleSink : ILogEventSink
+    class BrowserConsoleSink : ILogEventSink
     {
-        private readonly IJSRuntime _runtime;
-        private readonly OutputTemplateRenderer _formatter;
+        readonly IJSRuntime _runtime;
+        readonly OutputTemplateRenderer _formatter;
 
         public BrowserConsoleSink(IJSRuntime runtime, OutputTemplateRenderer formatter)
         {
@@ -31,15 +31,15 @@ namespace Serilog.Sinks.BrowserConsole
             _formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
         }
 
-        public async void Emit(LogEvent logEvent)
+        public void Emit(LogEvent logEvent)
         {
             if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
             var outputStream = SelectConsoleMethod(logEvent.Level);
             var args = _formatter.Format(logEvent);
-            await _runtime.InvokeAsync<string>(outputStream, args);
+            var _ = _runtime.InvokeAsync<string>(outputStream, args);
         }
 
-        private static string SelectConsoleMethod(LogEventLevel logLevel) =>
+        static string SelectConsoleMethod(LogEventLevel logLevel) =>
             logLevel switch
             {
                 >= LogEventLevel.Error => "console.error",

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/DefaultWebAssemblyJSRuntime.cs
@@ -20,31 +20,31 @@ using Microsoft.JSInterop.WebAssembly;
 
 namespace Serilog.Sinks.BrowserConsole
 {
-    internal sealed class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
+    sealed class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
     {
         internal static readonly DefaultWebAssemblyJSRuntime Instance = new DefaultWebAssemblyJSRuntime();
 
         public ElementReferenceContext ElementReferenceContext { get; }
 
-        private DefaultWebAssemblyJSRuntime()
+        DefaultWebAssemblyJSRuntime()
         {
             ElementReferenceContext = new WebElementReferenceContext(this);
             JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
         }
 
         #pragma warning disable IDE0051 // Remove unused private members. Invoked via Mono's JS interop mechanism (invoke_method)
-        private static string InvokeDotNet(string assemblyName, string methodIdentifier, string dotNetObjectId, string argsJson)
+        static string InvokeDotNet(string assemblyName, string methodIdentifier, string dotNetObjectId, string argsJson)
         {
             var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId == null ? default : long.Parse(dotNetObjectId), callId: null);
             return DotNetDispatcher.Invoke(Instance, callInfo, argsJson);
         }
 
         // Invoked via Mono's JS interop mechanism (invoke_method)
-        private static void EndInvokeJS(string argsJson)
+        static void EndInvokeJS(string argsJson)
             => DotNetDispatcher.EndInvokeJS(Instance, argsJson);
 
         // Invoked via Mono's JS interop mechanism (invoke_method)
-        private static void BeginInvokeDotNet(string callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
+        static void BeginInvokeDotNet(string callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
         {
             // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID
             // We only need one for any given call. This helps to work around the limitation that we can

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/ElementReferenceJsonConverter.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/ElementReferenceJsonConverter.cs
@@ -21,11 +21,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace Serilog.Sinks.BrowserConsole
 {
-    internal sealed class ElementReferenceJsonConverter : JsonConverter<ElementReference>
+    sealed class ElementReferenceJsonConverter : JsonConverter<ElementReference>
     {
-        private static readonly JsonEncodedText IdProperty = JsonEncodedText.Encode("__internalId");
+        static readonly JsonEncodedText IdProperty = JsonEncodedText.Encode("__internalId");
 
-        private readonly ElementReferenceContext _elementReferenceContext;
+        readonly ElementReferenceContext _elementReferenceContext;
 
         public ElementReferenceJsonConverter(ElementReferenceContext elementReferenceContext)
         {

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/ExceptionTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/ExceptionTokenRenderer.cs
@@ -17,16 +17,12 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class ExceptionTokenRenderer : OutputTemplateTokenRenderer
+    class ExceptionTokenRenderer : OutputTemplateTokenRenderer
     {
-        /// <summary>
-        /// "Renders" <see cref="Exception"/> to array of single exception element, if exception is not <see langword="null"/>.
-        /// If logevent has no exception set the result will be empty array of objects
-        /// </summary>
-        /// <param name="logEvent">Logging event that should be rendered</param>
-        /// <returns>Array of objects to pass to browser console</returns>
-        public override object[] Render(LogEvent logEvent) =>
-            logEvent.Exception is null ? 
-                Array.Empty<object>() : new object[] {logEvent.Exception.ToString()};
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+        {
+            if (logEvent.Exception is not null)
+                emitToken(logEvent.Exception.ToString());
+        }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelOutputFormat.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelOutputFormat.cs
@@ -23,9 +23,9 @@ namespace Serilog.Sinks.BrowserConsole.Output
     /// Width is set through formats like "u3" (uppercase three chars),
     /// "w1" (one lowercase char), or "t4" (title case four chars).
     /// </summary>
-    internal static class LevelOutputFormat
+    static class LevelOutputFormat
     {
-        private static readonly string[][] TitleCaseLevelMap =
+        static readonly string[][] TitleCaseLevelMap =
         {
             new[] { "V", "Vb", "Vrb", "Verb" },
             new[] { "D", "De", "Dbg", "Dbug" },
@@ -35,7 +35,7 @@ namespace Serilog.Sinks.BrowserConsole.Output
             new[] { "F", "Fa", "Ftl", "Fatl" }
         };
 
-        private static readonly string[][] LowercaseLevelMap =
+        static readonly string[][] LowercaseLevelMap =
         {
             new[] { "v", "vb", "vrb", "verb" },
             new[] { "d", "de", "dbg", "dbug" },
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.BrowserConsole.Output
             new[] { "f", "fa", "ftl", "fatl" }
         };
 
-        private static readonly string[][] UppercaseLevelMap =
+        static readonly string[][] UppercaseLevelMap =
         {
             new[] { "V", "VB", "VRB", "VERB" },
             new[] { "D", "DE", "DBG", "DBUG" },

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelTokenRenderer.cs
@@ -18,20 +18,20 @@ using Serilog.Sinks.BrowserConsole.Rendering;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class LevelTokenRenderer : OutputTemplateTokenRenderer
+    class LevelTokenRenderer : OutputTemplateTokenRenderer
     {
-        private readonly PropertyToken _levelToken;
+        readonly PropertyToken _levelToken;
 
         public LevelTokenRenderer(PropertyToken levelToken)
         {
             _levelToken = levelToken;
         }
 
-        public override object[] Render(LogEvent logEvent)
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
         {
             var moniker = LevelOutputFormat.GetLevelMoniker(logEvent.Level, _levelToken.Format);
-            var allignedOutput = Padding.Apply(moniker, _levelToken.Alignment);
-            return new object[] {allignedOutput};
+            var alignedOutput = Padding.Apply(moniker, _levelToken.Alignment);
+            emitToken(alignedOutput);
         }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/MessageTemplateOutputTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/MessageTemplateOutputTokenRenderer.cs
@@ -19,28 +19,25 @@ using Serilog.Parsing;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class MessageTemplateOutputTokenRenderer : OutputTemplateTokenRenderer
+    class MessageTemplateOutputTokenRenderer : OutputTemplateTokenRenderer
     {   
-        public override object[] Render(LogEvent logEvent)
-        {            
-            var result = new List<object>();
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+        {
             foreach (var token in logEvent.MessageTemplate.Tokens)
             {
                 switch (token)
                 {
                     case TextToken tt:
-                        result.Add(tt.Text);
+                        emitToken(tt.Text);
                         break;
                     case PropertyToken pt:
                         if (logEvent.Properties.TryGetValue(pt.PropertyName, out var propertyValue))
-                            result.Add(ObjectModelInterop.ToInteropValue(propertyValue));
+                            emitToken(ObjectModelInterop.ToInteropValue(propertyValue));
                         break;
                     default:
                         throw new InvalidOperationException();
                 }
             }
-
-            return result.ToArray();         
         }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/NewLineTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/NewLineTokenRenderer.cs
@@ -19,23 +19,21 @@ using Serilog.Sinks.BrowserConsole.Rendering;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class NewLineTokenRenderer : OutputTemplateTokenRenderer
+    class NewLineTokenRenderer : OutputTemplateTokenRenderer
     {
-        private readonly Alignment? _alignment;
+        readonly Alignment? _alignment;
 
         public NewLineTokenRenderer(Alignment? alignment)
         {
             _alignment = alignment;
         }
 
-        public override object[] Render(LogEvent logEvent) =>
-            new object[]
-            {
-                _alignment switch
-                {
-                    null => Environment.NewLine,
-                    { } => Padding.Apply(Environment.NewLine, _alignment.Value.Widen(Environment.NewLine.Length))
-                }
-            };
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+        {
+            if (_alignment is not null)
+                emitToken(Padding.Apply(Environment.NewLine, _alignment.Value.Widen(Environment.NewLine.Length)));
+            else
+                emitToken(Environment.NewLine);
+        }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Serilog.Events;
 using Serilog.Formatting.Display;
@@ -6,9 +7,9 @@ using Serilog.Parsing;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class OutputTemplateRenderer
+    class OutputTemplateRenderer
     {
-        private readonly OutputTemplateTokenRenderer[] _renderers;
+        readonly OutputTemplateTokenRenderer[] _renderers;
 
         public OutputTemplateRenderer(string outputTemplate, IFormatProvider formatProvider)
         {
@@ -38,7 +39,12 @@ namespace Serilog.Sinks.BrowserConsole.Output
         {
             if (logEvent is null) throw new ArgumentNullException(nameof(logEvent));
 
-            return _renderers.SelectMany(r => r.Render(logEvent)).ToArray();
+            var buffer = new List<object>(_renderers.Length * 2);
+            foreach (var renderer in _renderers)
+            {
+                renderer.Render(logEvent, buffer.Add);
+            }
+            return buffer.ToArray();
         }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateTokenRenderer.cs
@@ -16,8 +16,10 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal abstract class OutputTemplateTokenRenderer
+    delegate void TokenEmitter(object token);
+    
+    abstract class OutputTemplateTokenRenderer
     {
-        public abstract object[] Render(LogEvent logEvent);
+        public abstract void Render(LogEvent logEvent, TokenEmitter emitToken);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TextTokenRenderer.cs
@@ -16,15 +16,18 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class TextTokenRenderer : OutputTemplateTokenRenderer
+    class TextTokenRenderer : OutputTemplateTokenRenderer
     {
-        private readonly string _text;
+        readonly string _text;
 
         public TextTokenRenderer(string text)
         {
             _text = text;
         }
 
-        public override object[] Render(LogEvent logEvent) => new object[] {_text};
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+        {
+            emitToken(_text);
+        }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TimestampTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TimestampTokenRenderer.cs
@@ -20,10 +20,10 @@ using Serilog.Sinks.BrowserConsole.Rendering;
 
 namespace Serilog.Sinks.BrowserConsole.Output
 {
-    internal class TimestampTokenRenderer : OutputTemplateTokenRenderer
+    class TimestampTokenRenderer : OutputTemplateTokenRenderer
     {
-        private readonly PropertyToken _token;
-        private readonly IFormatProvider _formatProvider;
+        readonly PropertyToken _token;
+        readonly IFormatProvider _formatProvider;
 
         public TimestampTokenRenderer(PropertyToken token, IFormatProvider formatProvider)
         {
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.BrowserConsole.Output
             _formatProvider = formatProvider;
         }
 
-        public override object[] Render(LogEvent logEvent)
+        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
         {
             // We need access to ScalarValue.Render() to avoid this alloc; just ensures
             // that custom format providers are supported properly.
@@ -40,14 +40,10 @@ namespace Serilog.Sinks.BrowserConsole.Output
             sv.Render(buffer, _token.Format, _formatProvider);
             var str = buffer.ToString();
 
-            return new object[]
-            {
-                _token.Alignment switch
-                {
-                    null => str,
-                    { } => Padding.Apply(str, _token.Alignment)
-                }
-            };
+            if (_token.Alignment is not null)
+                emitToken(Padding.Apply(str, _token.Alignment));
+            else
+                emitToken(str);
         }
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/AlignmentExtensions.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/AlignmentExtensions.cs
@@ -16,7 +16,7 @@ using Serilog.Parsing;
 
 namespace Serilog.Sinks.BrowserConsole.Rendering
 {
-    internal static class AlignmentExtensions
+    static class AlignmentExtensions
     {
         public static Alignment Widen(this Alignment alignment, int amount) => new(alignment.Direction, alignment.Width + amount);
     }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Casing.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Casing.cs
@@ -14,7 +14,7 @@
 
 namespace Serilog.Sinks.BrowserConsole.Rendering
 {
-    internal static class Casing
+    static class Casing
     {
         /// <summary>
         /// Apply upper or lower casing to <paramref name="value"/> when <paramref name="format"/> is provided.

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Padding.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Padding.cs
@@ -17,7 +17,7 @@ using Serilog.Parsing;
 
 namespace Serilog.Sinks.BrowserConsole.Rendering
 {
-    internal static class Padding
+    static class Padding
     {
         /// <summary>
         /// Constructs the output string containing the provided value and


### PR DESCRIPTION
cc @zetroot 

Styles up the default template to make it a bit more Blazor-ish:

![image](https://user-images.githubusercontent.com/342712/117592014-36e47380-b17a-11eb-9cce-a0a764de4fd4.png)
