### PR TITLE
Update to Serilog 4, .NET 8, C# 12, `Microsoft.AspNetCore.Components.WebAssembly` 8.x.

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -23,14 +23,15 @@ foreach ($src in ls src/*) {
 
 	echo "build: Packaging project in $src"
 
-    & dotnet build -c Release --version-suffix=$buildSuffix
+    & dotnet build -c Release  /p:ContinuousIntegrationBuild=True --version-suffix=$buildSuffix
+    if($LASTEXITCODE -ne 0) { throw "Build failed" }
 
     if($suffix) {
         & dotnet pack -c Release --no-build -o ..\..\artifacts --version-suffix=$suffix
     } else {
         & dotnet pack -c Release --no-build -o ..\..\artifacts
     }
-    if($LASTEXITCODE -ne 0) { exit 1 }
+    if($LASTEXITCODE -ne 0) { throw "Packaging failed" }
 
     Pop-Location
 }
@@ -41,7 +42,7 @@ foreach ($test in ls test/*.Tests) {
 	echo "build: Testing project in $test"
 
     & dotnet test -c Release
-    if($LASTEXITCODE -ne 0) { exit 3 }
+    if($LASTEXITCODE -ne 0) { throw "Testing failed failed" }
 
     Pop-Location
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Serilog.Sinks.BrowserConsole [![Build status](https://ci.appveyor.com/api/projects/status/s458q719m2pfwnyk?svg=true)](https://ci.appveyor.com/project/serilog/serilog-sinks-browserconsole) [![NuGet Pre Release](https://img.shields.io/nuget/vpre/Serilog.Sinks.BrowserConsole.svg)](https://nuget.org/packages/Serilog.Sinks.BrowserConsole)
 
-A console sink for the Blazor/Wasm environment.
+A Serilog sink that takes advantage of the unique features of the browser console in the Blazor/WASM applications.
+
+**Versioning:** This package tracks the versioning and target framework support of its _Microsoft.AspNetCore.Components.WebAssembly_ dependency. Most users should choose the version of _Serilog.Sinks.BrowserConsole_ that matches their application's target framework. I.e. if you're targeting .NET 7.x, choose a 7.x version of _Serilog.Sinks.BrowserConsole_. If you're targeting .NET 8.x, choose an 8.x _Serilog.Sinks.BrowserConsole_ version, and so on.
 
 ### What's it do?
 
@@ -13,7 +15,7 @@ The sink writes log events to the browser console. Unlike the normal Serilog con
 Configure the logging pipeline in `Program.Main()`:
 
 ```csharp
-// dotnet add package Serilog.Sinks.BrowserConsole -v ...
+// dotnet add package Serilog.Sinks.BrowserConsole
 
 Log.Logger = new LoggerConfiguration()
     .WriteTo.BrowserConsole()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,29 +1,24 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2022
-test: off
-install:
-- ps: $RequiredDotnetVersion =  $(Get-Content ./global.json | ConvertFrom-Json).sdk.version
-- ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
-- ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
-- ps: Invoke-WebRequest -Uri "https://dot.net/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
-- ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version $RequiredDotnetVersion -InstallDir $env:DOTNET_INSTALL_DIR'
-- ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
+image:
+  - Visual Studio 2022
 build_script:
-- ps: ./Build.ps1
+  - pwsh: ./Build.ps1
+test: off
 artifacts:
-- path: artifacts/Serilog.*.nupkg
+  - path: artifacts/Serilog.*.nupkg
+  - path: artifacts/Serilog.*.snupkg
 deploy:
-- provider: NuGet
-  api_key:
-    secure: +2WKSa0MD8rYcyOATIFS3hOQQ6DpbabIqbldh/yFBajpeHwahh+pENharnkJgdn4
-  skip_symbols: true
-  on:
-    branch: /^(main|dev)$/
-- provider: GitHub
-  auth_token:
-    secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
-  artifact: /Serilog.*\.nupkg/
-  tag: v$(appveyor_build_version)
-  on:
-    branch: main
+  - provider: NuGet
+    api_key:
+      secure: sDnchSg4TZIOK7oIUI6BJwFPNENTOZrGNsroGO1hehLJSvlHpFmpTwiX8+bgPD+Q
+    on:
+      branch: /^(main|dev)$/
+  - provider: GitHub
+    auth_token:
+      secure: p4LpVhBKxGS5WqucHxFQ5c7C8cP74kbNB0Z8k9Oxx/PMaDQ1+ibmoexNqVU5ZlmX
+    artifact: /Serilog.*(\.|\.s)nupkg/
+    tag: v$(appveyor_build_version)
+    on:
+      branch: main
+      

--- a/example/ExampleClient/ExampleClient.csproj
+++ b/example/ExampleClient/ExampleClient.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="7.0.0" />
-    <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.7" />
+    <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/ExampleClient/Program.cs
+++ b/example/ExampleClient/Program.cs
@@ -6,12 +6,12 @@ using Serilog;
 using Serilog.Debugging;
 using System.Threading.Tasks;
 
-namespace ExampleClient
+namespace ExampleClient;
+
+public class Program
 {
-    public class Program
+    public static async Task Main(string[] args)
     {
-        public static async Task Main(string[] args)
-        {
             SelfLog.Enable(m => Console.Error.WriteLine(m));
 
             Log.Logger = new LoggerConfiguration()
@@ -38,5 +38,4 @@ namespace ExampleClient
                 throw;
             }
         }
-    }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-  "sdk": {
-    "version": "7.0.100",
-    "rollForward": "latestFeature"
-  }
-}

--- a/serilog-sinks-browserconsole.sln
+++ b/serilog-sinks-browserconsole.sln
@@ -10,7 +10,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sln", "sln", "{92992D61-AAE
 		Build.ps1 = Build.ps1
 		LICENSE = LICENSE
 		README.md = README.md
-		global.json = global.json
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{B4B852D3-EAD7-40BC-AE0C-2C7FF8E3D9BE}"

--- a/serilog-sinks-browserconsole.sln.DotSettings
+++ b/serilog-sinks-browserconsole.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=JS/@EntryIndexedValue">JS</s:String></wpf:ResourceDictionary>

--- a/src/Serilog.Sinks.BrowserConsole/LoggerConfigurationBrowserConsoleExtensions.cs
+++ b/src/Serilog.Sinks.BrowserConsole/LoggerConfigurationBrowserConsoleExtensions.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Microsoft.JSInterop;
 using Serilog.Configuration;
 using Serilog.Core;
@@ -20,42 +19,41 @@ using Serilog.Events;
 using Serilog.Sinks.BrowserConsole;
 using Serilog.Sinks.BrowserConsole.Output;
 
-namespace Serilog
+namespace Serilog;
+
+/// <summary>
+/// Adds the WriteTo.BrowserConsole() extension method to <see cref="LoggerConfiguration"/>.
+/// </summary>
+public static class LoggerConfigurationBrowserConsoleExtensions
 {
-    /// <summary>
-    /// Adds the WriteTo.BrowserConsole() extension method to <see cref="LoggerConfiguration"/>.
-    /// </summary>
-    public static class LoggerConfigurationBrowserConsoleExtensions
-    {
-        const string SerilogToken =
-            "%cserilog{_}color:white;background:#8c7574;border-radius:3px;padding:1px 2px;font-weight:600;";
+    const string SerilogToken =
+        "%cserilog{_}color:white;background:#8c7574;border-radius:3px;padding:1px 2px;font-weight:600;";
             
-        const string DefaultConsoleOutputTemplate = SerilogToken + "{Message}{NewLine}{Exception}";
+    const string DefaultConsoleOutputTemplate = SerilogToken + "{Message}{NewLine}{Exception}";
         
-        /// <summary>
-        /// Writes log events to the browser console.
-        /// </summary>
-        /// <param name="sinkConfiguration">Logger sink configuration.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum level for
-        /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
-        /// <param name="outputTemplate">A message template describing the format used to write to the sink.
-        /// The default is <code>"[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"</code>.</param>
-        /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
-        /// <param name="levelSwitch">A switch allowing the pass-through minimum level
-        /// to be changed at runtime.</param>
-        /// <param name="jsRuntime">An instance of <see cref="IJSRuntime"/> to interact with the browser.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration BrowserConsole(
-            this LoggerSinkConfiguration sinkConfiguration,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            string outputTemplate = DefaultConsoleOutputTemplate,
-            IFormatProvider formatProvider = null,
-            LoggingLevelSwitch levelSwitch = null,
-			IJSRuntime jsRuntime = null)
-        {
-            if (sinkConfiguration == null) throw new ArgumentNullException(nameof(sinkConfiguration));
-            var formatter = new OutputTemplateRenderer(outputTemplate, formatProvider); 
-            return sinkConfiguration.Sink(new BrowserConsoleSink(jsRuntime, formatter), restrictedToMinimumLevel, levelSwitch);
-        }
+    /// <summary>
+    /// Writes log events to the browser console.
+    /// </summary>
+    /// <param name="sinkConfiguration">Logger sink configuration.</param>
+    /// <param name="restrictedToMinimumLevel">The minimum level for
+    /// events passed through the sink. Ignored when <paramref name="levelSwitch"/> is specified.</param>
+    /// <param name="outputTemplate">A message template describing the format used to write to the sink.
+    /// The default is <code>"[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"</code>.</param>
+    /// <param name="formatProvider">Supplies culture-specific formatting information, or null.</param>
+    /// <param name="levelSwitch">A switch allowing the pass-through minimum level
+    /// to be changed at runtime.</param>
+    /// <param name="jsRuntime">An instance of <see cref="IJSRuntime"/> to interact with the browser.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static LoggerConfiguration BrowserConsole(
+        this LoggerSinkConfiguration sinkConfiguration,
+        LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+        string outputTemplate = DefaultConsoleOutputTemplate,
+        IFormatProvider? formatProvider = null,
+        LoggingLevelSwitch? levelSwitch = null,
+        IJSRuntime? jsRuntime = null)
+    {
+        ArgumentNullException.ThrowIfNull(sinkConfiguration);
+        var formatter = new OutputTemplateRenderer(outputTemplate, formatProvider); 
+        return sinkConfiguration.Sink(new BrowserConsoleSink(jsRuntime, formatter), restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Properties/AssemblyInfo.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Properties/AssemblyInfo.cs
@@ -1,5 +1,0 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-
-[assembly: AssemblyVersion("1.0.0")]
-[assembly: InternalsVisibleTo("Serilog.Sinks.BrowserConsole.Tests")]

--- a/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
+++ b/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <!-- TFMs supported by this package are aligned with Microsoft.AspNetCore.Components.WebAssembly supported TFMs. -->
     <VersionPrefix>8.0.0</VersionPrefix>
     <RootNamespace>Serilog</RootNamespace>
     <Description>Writes Serilog events to the browser console</Description>

--- a/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
+++ b/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <RootNamespace>Serilog</RootNamespace>
     <Description>Writes Serilog events to the browser console</Description>
     <Authors>Serilog Contributors</Authors>

--- a/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
+++ b/src/Serilog.Sinks.BrowserConsole/Serilog.Sinks.BrowserConsole.csproj
@@ -1,30 +1,39 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <VersionPrefix>2.0.1</VersionPrefix>
+    <TargetFramework>net8.0</TargetFramework>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <RootNamespace>Serilog</RootNamespace>
-    <Description>Simple .NET logging with fully-structured events</Description>
+    <Description>Writes Serilog events to the browser console</Description>
     <Authors>Serilog Contributors</Authors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>serilog;blazor</PackageTags>
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/serilog/serilog-sinks-browserconsole</PackageProjectUrl>
 	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/serilog/serilog-sinks-browserconsole</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <Nullable>enable</Nullable>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <IncludeSymbols>true</IncludeSymbols>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <InternalsVisibleTo Include="Serilog.Sinks.BrowserConsole.Tests" />
+  </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="7.0.0" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.7" />
+    <PackageReference Include="Serilog" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>
     <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Include="..\..\README.md" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/BrowserConsoleSink.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/BrowserConsoleSink.cs
@@ -12,41 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Microsoft.JSInterop;
 using Serilog.Core;
+using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.BrowserConsole.Output;
 
-namespace Serilog.Sinks.BrowserConsole
+namespace Serilog.Sinks.BrowserConsole;
+
+class BrowserConsoleSink : ILogEventSink
 {
-    class BrowserConsoleSink : ILogEventSink
+    readonly IJSRuntime _runtime;
+    readonly OutputTemplateRenderer _formatter;
+
+    public BrowserConsoleSink(IJSRuntime? runtime, OutputTemplateRenderer formatter)
     {
-        readonly IJSRuntime _runtime;
-        readonly OutputTemplateRenderer _formatter;
-
-        public BrowserConsoleSink(IJSRuntime runtime, OutputTemplateRenderer formatter)
-        {
-            _runtime = runtime ?? DefaultWebAssemblyJSRuntime.Instance;
-            _formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
-        }
-
-        public void Emit(LogEvent logEvent)
-        {
-            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
-            var outputStream = SelectConsoleMethod(logEvent.Level);
-            var args = _formatter.Format(logEvent);
-            var _ = _runtime.InvokeAsync<string>(outputStream, args);
-        }
-
-        static string SelectConsoleMethod(LogEventLevel logLevel) =>
-            logLevel switch
-            {
-                >= LogEventLevel.Error => "console.error",
-                LogEventLevel.Warning => "console.warn",
-                LogEventLevel.Information => "console.info",
-                LogEventLevel.Debug => "console.debug",
-                _ => "console.log"
-            };
+        _runtime = runtime ?? DefaultWebAssemblyJSRuntime.Instance;
+        _formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
     }
+
+    public void Emit(LogEvent logEvent)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+        var outputStream = SelectConsoleMethod(logEvent.Level);
+        var args = _formatter.Format(logEvent);
+        _runtime.InvokeAsync<string>(outputStream, args)
+            .AsTask()
+            .ContinueWith(t => SelfLog.WriteLine("Failed to emit log event: {0}", t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+    }
+
+    static string SelectConsoleMethod(LogEventLevel logLevel) =>
+        logLevel switch
+        {
+            >= LogEventLevel.Error => "console.error",
+            LogEventLevel.Warning => "console.warn",
+            LogEventLevel.Information => "console.info",
+            LogEventLevel.Debug => "console.debug",
+            _ => "console.log"
+        };
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/DefaultWebAssemblyJSRuntime.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/DefaultWebAssemblyJSRuntime.cs
@@ -17,54 +17,54 @@
 using Microsoft.AspNetCore.Components;
 using Microsoft.JSInterop.Infrastructure;
 using Microsoft.JSInterop.WebAssembly;
+// ReSharper disable UnusedMember.Local
 
-namespace Serilog.Sinks.BrowserConsole
+namespace Serilog.Sinks.BrowserConsole;
+
+sealed class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
 {
-    sealed class DefaultWebAssemblyJSRuntime : WebAssemblyJSRuntime
+    internal static readonly DefaultWebAssemblyJSRuntime Instance = new();
+
+    ElementReferenceContext ElementReferenceContext { get; }
+
+    DefaultWebAssemblyJSRuntime()
     {
-        internal static readonly DefaultWebAssemblyJSRuntime Instance = new DefaultWebAssemblyJSRuntime();
-
-        public ElementReferenceContext ElementReferenceContext { get; }
-
-        DefaultWebAssemblyJSRuntime()
-        {
-            ElementReferenceContext = new WebElementReferenceContext(this);
-            JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
-        }
-
-        #pragma warning disable IDE0051 // Remove unused private members. Invoked via Mono's JS interop mechanism (invoke_method)
-        static string InvokeDotNet(string assemblyName, string methodIdentifier, string dotNetObjectId, string argsJson)
-        {
-            var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId == null ? default : long.Parse(dotNetObjectId), callId: null);
-            return DotNetDispatcher.Invoke(Instance, callInfo, argsJson);
-        }
-
-        // Invoked via Mono's JS interop mechanism (invoke_method)
-        static void EndInvokeJS(string argsJson)
-            => DotNetDispatcher.EndInvokeJS(Instance, argsJson);
-
-        // Invoked via Mono's JS interop mechanism (invoke_method)
-        static void BeginInvokeDotNet(string callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
-        {
-            // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID
-            // We only need one for any given call. This helps to work around the limitation that we can
-            // only pass a maximum of 4 args in a call from JS to Mono WebAssembly.
-            string assemblyName;
-            long dotNetObjectId;
-            if (char.IsDigit(assemblyNameOrDotNetObjectId[0]))
-            {
-                dotNetObjectId = long.Parse(assemblyNameOrDotNetObjectId);
-                assemblyName = null;
-            }
-            else
-            {
-                dotNetObjectId = default;
-                assemblyName = assemblyNameOrDotNetObjectId;
-            }
-
-            var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId, callId);
-            DotNetDispatcher.BeginInvokeDotNet(Instance, callInfo, argsJson);
-        }
-        #pragma warning restore IDE0051
+        ElementReferenceContext = new WebElementReferenceContext(this);
+        JsonSerializerOptions.Converters.Add(new ElementReferenceJsonConverter(ElementReferenceContext));
     }
+
+#pragma warning disable IDE0051 // Remove unused private members. Invoked via Mono's JS interop mechanism (invoke_method)
+    static string? InvokeDotNet(string assemblyName, string methodIdentifier, string? dotNetObjectId, string argsJson)
+    {
+        var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId == null ? default : long.Parse(dotNetObjectId), callId: null);
+        return DotNetDispatcher.Invoke(Instance, callInfo, argsJson);
+    }
+
+    // Invoked via Mono's JS interop mechanism (invoke_method)
+    static void EndInvokeJS(string argsJson)
+        => DotNetDispatcher.EndInvokeJS(Instance, argsJson);
+
+    // Invoked via Mono's JS interop mechanism (invoke_method)
+    static void BeginInvokeDotNet(string callId, string assemblyNameOrDotNetObjectId, string methodIdentifier, string argsJson)
+    {
+        // Figure out whether 'assemblyNameOrDotNetObjectId' is the assembly name or the instance ID
+        // We only need one for any given call. This helps to work around the limitation that we can
+        // only pass a maximum of 4 args in a call from JS to Mono WebAssembly.
+        string? assemblyName;
+        long dotNetObjectId;
+        if (char.IsDigit(assemblyNameOrDotNetObjectId[0]))
+        {
+            dotNetObjectId = long.Parse(assemblyNameOrDotNetObjectId);
+            assemblyName = null;
+        }
+        else
+        {
+            dotNetObjectId = default;
+            assemblyName = assemblyNameOrDotNetObjectId;
+        }
+
+        var callInfo = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId, callId);
+        DotNetDispatcher.BeginInvokeDotNet(Instance, callInfo, argsJson);
+    }
+#pragma warning restore IDE0051
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/EventPropertyTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/EventPropertyTokenRenderer.cs
@@ -12,54 +12,51 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.IO;
 using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.BrowserConsole.Rendering;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class EventPropertyTokenRenderer : OutputTemplateTokenRenderer
 {
-    class EventPropertyTokenRenderer : OutputTemplateTokenRenderer
+    readonly PropertyToken _token;
+    readonly IFormatProvider? _formatProvider;
+
+    public EventPropertyTokenRenderer(PropertyToken token, IFormatProvider? formatProvider)
     {
-        readonly PropertyToken _token;
-        readonly IFormatProvider _formatProvider;
+        _token = token;
+        _formatProvider = formatProvider;
+    }
 
-        public EventPropertyTokenRenderer(PropertyToken token, IFormatProvider formatProvider)
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+    {
+        // If a property is missing, don't render anything (message templates render the raw token here).
+        if (!logEvent.Properties.TryGetValue(_token.PropertyName, out var propertyValue))
         {
-            _token = token;
-            _formatProvider = formatProvider;
-        }
-
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
-        {
-            // If a property is missing, don't render anything (message templates render the raw token here).
-            if (!logEvent.Properties.TryGetValue(_token.PropertyName, out var propertyValue))
-            {
-                if (_token.Alignment is not null)
-                    emitToken(Padding.Apply(string.Empty, _token.Alignment));
-                return;
-            }
-
-            var writer = new StringWriter();
-
-            // If the value is a scalar string, support some additional formats: 'u' for uppercase
-            // and 'w' for lowercase.
-            if (propertyValue is ScalarValue {Value: string literalString})
-            {
-                var cased = Casing.Format(literalString, _token.Format);
-                writer.Write(cased);
-            }
-            else
-            {
-                propertyValue.Render(writer, _token.Format, _formatProvider);
-            }
-
-            var str = writer.ToString();
             if (_token.Alignment is not null)
-                emitToken(Padding.Apply(str, _token.Alignment));
-            else
-                emitToken(str);
+                emitToken(Padding.Apply(string.Empty, _token.Alignment));
+            return;
         }
+
+        var writer = new StringWriter();
+
+        // If the value is a scalar string, support some additional formats: 'u' for uppercase
+        // and 'w' for lowercase.
+        if (propertyValue is ScalarValue {Value: string literalString})
+        {
+            var cased = Casing.Format(literalString, _token.Format);
+            writer.Write(cased);
+        }
+        else
+        {
+            propertyValue.Render(writer, _token.Format, _formatProvider);
+        }
+
+        var str = writer.ToString();
+        if (_token.Alignment is not null)
+            emitToken(Padding.Apply(str, _token.Alignment));
+        else
+            emitToken(str);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/ExceptionTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/ExceptionTokenRenderer.cs
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Serilog.Events;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class ExceptionTokenRenderer : OutputTemplateTokenRenderer
 {
-    class ExceptionTokenRenderer : OutputTemplateTokenRenderer
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
     {
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
-        {
-            if (logEvent.Exception is not null)
-                emitToken(logEvent.Exception.ToString());
-        }
+        if (logEvent.Exception is not null)
+            emitToken(logEvent.Exception.ToString());
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelOutputFormat.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelOutputFormat.cs
@@ -15,88 +15,87 @@
 using Serilog.Events;
 using Serilog.Sinks.BrowserConsole.Rendering;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+/// <summary>
+/// Implements the {Level} element.
+/// can now have a fixed width applied to it, as well as casing rules.
+/// Width is set through formats like "u3" (uppercase three chars),
+/// "w1" (one lowercase char), or "t4" (title case four chars).
+/// </summary>
+static class LevelOutputFormat
 {
-    /// <summary>
-    /// Implements the {Level} element.
-    /// can now have a fixed width applied to it, as well as casing rules.
-    /// Width is set through formats like "u3" (uppercase three chars),
-    /// "w1" (one lowercase char), or "t4" (title case four chars).
-    /// </summary>
-    static class LevelOutputFormat
+    static readonly string[][] TitleCaseLevelMap =
+    [
+        ["V", "Vb", "Vrb", "Verb"],
+        ["D", "De", "Dbg", "Dbug"],
+        ["I", "In", "Inf", "Info"],
+        ["W", "Wn", "Wrn", "Warn"],
+        ["E", "Er", "Err", "Eror"],
+        ["F", "Fa", "Ftl", "Fatl"]
+    ];
+
+    static readonly string[][] LowercaseLevelMap =
+    [
+        ["v", "vb", "vrb", "verb"],
+        ["d", "de", "dbg", "dbug"],
+        ["i", "in", "inf", "info"],
+        ["w", "wn", "wrn", "warn"],
+        ["e", "er", "err", "eror"],
+        ["f", "fa", "ftl", "fatl"]
+    ];
+
+    static readonly string[][] UppercaseLevelMap =
+    [
+        ["V", "VB", "VRB", "VERB"],
+        ["D", "DE", "DBG", "DBUG"],
+        ["I", "IN", "INF", "INFO"],
+        ["W", "WN", "WRN", "WARN"],
+        ["E", "ER", "ERR", "EROR"],
+        ["F", "FA", "FTL", "FATL"]
+    ];
+
+    public static string GetLevelMoniker(LogEventLevel value, string? format = null)
     {
-        static readonly string[][] TitleCaseLevelMap =
-        {
-            new[] { "V", "Vb", "Vrb", "Verb" },
-            new[] { "D", "De", "Dbg", "Dbug" },
-            new[] { "I", "In", "Inf", "Info" },
-            new[] { "W", "Wn", "Wrn", "Warn" },
-            new[] { "E", "Er", "Err", "Eror" },
-            new[] { "F", "Fa", "Ftl", "Fatl" }
-        };
-
-        static readonly string[][] LowercaseLevelMap =
-        {
-            new[] { "v", "vb", "vrb", "verb" },
-            new[] { "d", "de", "dbg", "dbug" },
-            new[] { "i", "in", "inf", "info" },
-            new[] { "w", "wn", "wrn", "warn" },
-            new[] { "e", "er", "err", "eror" },
-            new[] { "f", "fa", "ftl", "fatl" }
-        };
-
-        static readonly string[][] UppercaseLevelMap =
-        {
-            new[] { "V", "VB", "VRB", "VERB" },
-            new[] { "D", "DE", "DBG", "DBUG" },
-            new[] { "I", "IN", "INF", "INFO" },
-            new[] { "W", "WN", "WRN", "WARN" },
-            new[] { "E", "ER", "ERR", "EROR" },
-            new[] { "F", "FA", "FTL", "FATL" }
-        };
-
-        public static string GetLevelMoniker(LogEventLevel value, string format = null)
-        {
-            if (format is null || format.Length != 2 && format.Length != 3)
-                return Casing.Format(value.ToString(), format);
-
-            // Using int.Parse() here requires allocating a string to exclude the first character prefix.
-            // Junk like "wxy" will be accepted but produce benign results.
-            var width = format[1] - '0';
-            if (format.Length == 3)
-            {
-                width *= 10;
-                width += format[2] - '0';
-            }
-
-            switch (width)
-            {
-                case < 1:
-                    return string.Empty;
-                case > 4:
-                {
-                    var stringValue = value.ToString();
-                    if (stringValue.Length > width)
-                        stringValue = stringValue.Substring(0, width);
-                    return Casing.Format(stringValue);
-                }
-            }
-
-            var index = (int)value;
-            if (index >= 0 && index <= (int)LogEventLevel.Fatal)
-            {
-                switch (format[0])
-                {
-                    case 'w':
-                        return LowercaseLevelMap[index][width - 1];
-                    case 'u':
-                        return UppercaseLevelMap[index][width - 1];
-                    case 't':
-                        return TitleCaseLevelMap[index][width - 1];
-                }
-            }
-
+        if (format is null || format.Length != 2 && format.Length != 3)
             return Casing.Format(value.ToString(), format);
+
+        // Using int.Parse() here requires allocating a string to exclude the first character prefix.
+        // Junk like "wxy" will be accepted but produce benign results.
+        var width = format[1] - '0';
+        if (format.Length == 3)
+        {
+            width *= 10;
+            width += format[2] - '0';
         }
+
+        switch (width)
+        {
+            case < 1:
+                return string.Empty;
+            case > 4:
+            {
+                var stringValue = value.ToString();
+                if (stringValue.Length > width)
+                    stringValue = stringValue.Substring(0, width);
+                return Casing.Format(stringValue);
+            }
+        }
+
+        var index = (int)value;
+        if (index is >= 0 and <= (int)LogEventLevel.Fatal)
+        {
+            switch (format[0])
+            {
+                case 'w':
+                    return LowercaseLevelMap[index][width - 1];
+                case 'u':
+                    return UppercaseLevelMap[index][width - 1];
+                case 't':
+                    return TitleCaseLevelMap[index][width - 1];
+            }
+        }
+
+        return Casing.Format(value.ToString(), format);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/LevelTokenRenderer.cs
@@ -16,22 +16,21 @@ using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.BrowserConsole.Rendering;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class LevelTokenRenderer : OutputTemplateTokenRenderer
 {
-    class LevelTokenRenderer : OutputTemplateTokenRenderer
+    readonly PropertyToken _levelToken;
+
+    public LevelTokenRenderer(PropertyToken levelToken)
     {
-        readonly PropertyToken _levelToken;
+        _levelToken = levelToken;
+    }
 
-        public LevelTokenRenderer(PropertyToken levelToken)
-        {
-            _levelToken = levelToken;
-        }
-
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
-        {
-            var moniker = LevelOutputFormat.GetLevelMoniker(logEvent.Level, _levelToken.Format);
-            var alignedOutput = Padding.Apply(moniker, _levelToken.Alignment);
-            emitToken(alignedOutput);
-        }
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+    {
+        var moniker = LevelOutputFormat.GetLevelMoniker(logEvent.Level, _levelToken.Format);
+        var alignedOutput = Padding.Apply(moniker, _levelToken.Alignment);
+        emitToken(alignedOutput);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/MessageTemplateOutputTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/MessageTemplateOutputTokenRenderer.cs
@@ -12,31 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.BrowserConsole.Output
-{
-    class MessageTemplateOutputTokenRenderer : OutputTemplateTokenRenderer
-    {   
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class MessageTemplateOutputTokenRenderer : OutputTemplateTokenRenderer
+{   
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+    {
+        foreach (var token in logEvent.MessageTemplate.Tokens)
         {
-            foreach (var token in logEvent.MessageTemplate.Tokens)
+            switch (token)
             {
-                switch (token)
-                {
-                    case TextToken tt:
-                        emitToken(tt.Text);
-                        break;
-                    case PropertyToken pt:
-                        if (logEvent.Properties.TryGetValue(pt.PropertyName, out var propertyValue))
-                            emitToken(ObjectModelInterop.ToInteropValue(propertyValue));
-                        break;
-                    default:
-                        throw new InvalidOperationException();
-                }
+                case TextToken tt:
+                    emitToken(tt.Text);
+                    break;
+                case PropertyToken pt:
+                    if (logEvent.Properties.TryGetValue(pt.PropertyName, out var propertyValue))
+                        emitToken(ObjectModelInterop.ToInteropValue(propertyValue));
+                    break;
+                default:
+                    throw new InvalidOperationException();
             }
         }
     }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/NewLineTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/NewLineTokenRenderer.cs
@@ -12,28 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using Serilog.Events;
 using Serilog.Parsing;
 using Serilog.Sinks.BrowserConsole.Rendering;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class NewLineTokenRenderer : OutputTemplateTokenRenderer
 {
-    class NewLineTokenRenderer : OutputTemplateTokenRenderer
+    readonly Alignment? _alignment;
+
+    public NewLineTokenRenderer(Alignment? alignment)
     {
-        readonly Alignment? _alignment;
+        _alignment = alignment;
+    }
 
-        public NewLineTokenRenderer(Alignment? alignment)
-        {
-            _alignment = alignment;
-        }
-
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
-        {
-            if (_alignment is not null)
-                emitToken(Padding.Apply(Environment.NewLine, _alignment.Value.Widen(Environment.NewLine.Length)));
-            else
-                emitToken(Environment.NewLine);
-        }
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+    {
+        if (_alignment is not null)
+            emitToken(Padding.Apply(Environment.NewLine, _alignment.Value.Widen(Environment.NewLine.Length)));
+        else
+            emitToken(Environment.NewLine);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateRenderer.cs
@@ -1,50 +1,46 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Serilog.Events;
+﻿using Serilog.Events;
 using Serilog.Formatting.Display;
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class OutputTemplateRenderer
 {
-    class OutputTemplateRenderer
+    readonly OutputTemplateTokenRenderer[] _renderers;
+
+    public OutputTemplateRenderer(string outputTemplate, IFormatProvider? formatProvider)
     {
-        readonly OutputTemplateTokenRenderer[] _renderers;
-
-        public OutputTemplateRenderer(string outputTemplate, IFormatProvider formatProvider)
-        {
-            if (outputTemplate is null) throw new ArgumentNullException(nameof(outputTemplate));
-            var template = new MessageTemplateParser().Parse(outputTemplate);
+        ArgumentNullException.ThrowIfNull(outputTemplate);
+        var template = new MessageTemplateParser().Parse(outputTemplate);
             
-            _renderers = template.Tokens
-                .Select(token => token switch
-                {
-                    TextToken tt => new TextTokenRenderer(tt.Text),
-                    PropertyToken pt => pt.PropertyName switch
-                    {
-                        OutputProperties.LevelPropertyName => new LevelTokenRenderer(pt) as OutputTemplateTokenRenderer,
-                        OutputProperties.NewLinePropertyName => new NewLineTokenRenderer(pt.Alignment),
-                        OutputProperties.ExceptionPropertyName => new ExceptionTokenRenderer(),
-                        OutputProperties.MessagePropertyName => new MessageTemplateOutputTokenRenderer(),
-                        OutputProperties.TimestampPropertyName => new TimestampTokenRenderer(pt, formatProvider),
-                        OutputProperties.PropertiesPropertyName => new PropertiesTokenRenderer(pt, template),
-                        _ => new EventPropertyTokenRenderer(pt, formatProvider)
-                    },
-                    _ => throw new InvalidOperationException()
-                })
-                .ToArray();
-        }
-
-        public object[] Format(LogEvent logEvent)
-        {
-            if (logEvent is null) throw new ArgumentNullException(nameof(logEvent));
-
-            var buffer = new List<object>(_renderers.Length * 2);
-            foreach (var renderer in _renderers)
+        _renderers = template.Tokens
+            .Select(token => token switch
             {
-                renderer.Render(logEvent, buffer.Add);
-            }
-            return buffer.ToArray();
+                TextToken tt => new TextTokenRenderer(tt.Text),
+                PropertyToken pt => pt.PropertyName switch
+                {
+                    OutputProperties.LevelPropertyName => new LevelTokenRenderer(pt) as OutputTemplateTokenRenderer,
+                    OutputProperties.NewLinePropertyName => new NewLineTokenRenderer(pt.Alignment),
+                    OutputProperties.ExceptionPropertyName => new ExceptionTokenRenderer(),
+                    OutputProperties.MessagePropertyName => new MessageTemplateOutputTokenRenderer(),
+                    OutputProperties.TimestampPropertyName => new TimestampTokenRenderer(pt, formatProvider),
+                    OutputProperties.PropertiesPropertyName => new PropertiesTokenRenderer(pt, template),
+                    _ => new EventPropertyTokenRenderer(pt, formatProvider)
+                },
+                _ => throw new InvalidOperationException()
+            })
+            .ToArray();
+    }
+
+    public object?[] Format(LogEvent logEvent)
+    {
+        ArgumentNullException.ThrowIfNull(logEvent);
+
+        var buffer = new List<object?>(_renderers.Length * 2);
+        foreach (var renderer in _renderers)
+        {
+            renderer.Render(logEvent, buffer.Add);
         }
+        return buffer.ToArray();
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/OutputTemplateTokenRenderer.cs
@@ -14,12 +14,11 @@
 
 using Serilog.Events;
 
-namespace Serilog.Sinks.BrowserConsole.Output
-{
-    delegate void TokenEmitter(object token);
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+delegate void TokenEmitter(object? token);
     
-    abstract class OutputTemplateTokenRenderer
-    {
-        public abstract void Render(LogEvent logEvent, TokenEmitter emitToken);
-    }
+abstract class OutputTemplateTokenRenderer
+{
+    public abstract void Render(LogEvent logEvent, TokenEmitter emitToken);
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TextTokenRenderer.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Output/TextTokenRenderer.cs
@@ -14,20 +14,19 @@
 
 using Serilog.Events;
 
-namespace Serilog.Sinks.BrowserConsole.Output
+namespace Serilog.Sinks.BrowserConsole.Output;
+
+class TextTokenRenderer : OutputTemplateTokenRenderer
 {
-    class TextTokenRenderer : OutputTemplateTokenRenderer
+    readonly string _text;
+
+    public TextTokenRenderer(string text)
     {
-        readonly string _text;
+        _text = text;
+    }
 
-        public TextTokenRenderer(string text)
-        {
-            _text = text;
-        }
-
-        public override void Render(LogEvent logEvent, TokenEmitter emitToken)
-        {
-            emitToken(_text);
-        }
+    public override void Render(LogEvent logEvent, TokenEmitter emitToken)
+    {
+        emitToken(_text);
     }
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/AlignmentExtensions.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/AlignmentExtensions.cs
@@ -14,10 +14,9 @@
 
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.BrowserConsole.Rendering
+namespace Serilog.Sinks.BrowserConsole.Rendering;
+
+static class AlignmentExtensions
 {
-    static class AlignmentExtensions
-    {
-        public static Alignment Widen(this Alignment alignment, int amount) => new(alignment.Direction, alignment.Width + amount);
-    }
+    public static Alignment Widen(this Alignment alignment, int amount) => new(alignment.Direction, alignment.Width + amount);
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Casing.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Casing.cs
@@ -12,23 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace Serilog.Sinks.BrowserConsole.Rendering
+namespace Serilog.Sinks.BrowserConsole.Rendering;
+
+static class Casing
 {
-    static class Casing
-    {
-        /// <summary>
-        /// Apply upper or lower casing to <paramref name="value"/> when <paramref name="format"/> is provided.
-        /// Returns <paramref name="value"/> when no or invalid format provided.
-        /// </summary>
-        /// <param name="value">Provided string for formatting.</param>
-        /// <param name="format">Format string.</param>
-        /// <returns>The provided <paramref name="value"/> with formatting applied.</returns>
-        public static string Format(string value, string format = null) =>
-            format switch
-            {
-                "u" => value.ToUpperInvariant(),
-                "w" => value.ToLowerInvariant(),
-                _ => value
-            };
-    }
+    /// <summary>
+    /// Apply upper or lower casing to <paramref name="value"/> when <paramref name="format"/> is provided.
+    /// Returns <paramref name="value"/> when no or invalid format provided.
+    /// </summary>
+    /// <param name="value">Provided string for formatting.</param>
+    /// <param name="format">Format string.</param>
+    /// <returns>The provided <paramref name="value"/> with formatting applied.</returns>
+    public static string Format(string value, string? format = null) =>
+        format switch
+        {
+            "u" => value.ToUpperInvariant(),
+            "w" => value.ToLowerInvariant(),
+            _ => value
+        };
 }

--- a/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Padding.cs
+++ b/src/Serilog.Sinks.BrowserConsole/Sinks/BrowserConsole/Rendering/Padding.cs
@@ -15,35 +15,34 @@
 using System.Text;
 using Serilog.Parsing;
 
-namespace Serilog.Sinks.BrowserConsole.Rendering
+namespace Serilog.Sinks.BrowserConsole.Rendering;
+
+static class Padding
 {
-    static class Padding
+    /// <summary>
+    /// Constructs the output string containing the provided value and
+    /// applying direction-based padding when <paramref name="alignment"/> is provided.
+    /// </summary>
+    /// <param name="value">Provided value.</param>
+    /// <param name="alignment">The alignment settings to apply when rendering <paramref name="value"/>.</param>
+    /// <returns>string with value and applied padding</returns>
+    public static string Apply(string value, Alignment? alignment)
     {
-        /// <summary>
-        /// Constructs the output string containing the provided value and
-        /// applying direction-based padding when <paramref name="alignment"/> is provided.
-        /// </summary>
-        /// <param name="value">Provided value.</param>
-        /// <param name="alignment">The alignment settings to apply when rendering <paramref name="value"/>.</param>
-        /// <returns>string with value and applied padding</returns>
-        public static string Apply(string value, Alignment? alignment)
+        if (alignment is null || value.Length >= alignment.Value.Width)
         {
-            if (alignment is null || value.Length >= alignment.Value.Width)
-            {
-                return value;
-            }
-
-            var sb = new StringBuilder();
-            var pad = alignment.Value.Width - value.Length;
-
-            if (alignment.Value.Direction == AlignmentDirection.Left)
-                sb.Append(value);
-
-            sb.Append(' ', pad);
-            
-            if (alignment.Value.Direction == AlignmentDirection.Right)
-                sb.Append(value);
-            return sb.ToString();
+            return value;
         }
+
+        var sb = new StringBuilder();
+        var pad = alignment.Value.Width - value.Length;
+
+        if (alignment.Value.Direction == AlignmentDirection.Left)
+            sb.Append(value);
+
+        sb.Append(' ', pad);
+            
+        if (alignment.Value.Direction == AlignmentDirection.Right)
+            sb.Append(value);
+        return sb.ToString();
     }
 }

--- a/test/Serilog.Sinks.BrowserConsole.Tests/ObjectModelInteropTests.cs
+++ b/test/Serilog.Sinks.BrowserConsole.Tests/ObjectModelInteropTests.cs
@@ -1,24 +1,23 @@
 using Serilog.Events;
 using Xunit;
 
-namespace Serilog.Sinks.BrowserConsole.Tests
-{
-    public class ObjectModelInteropTests
-    {
-        [Fact]
-        public void ScalarsInteropAsTheirValue()
-        {
-            var sv = new ScalarValue(14);
-            var iv = ObjectModelInterop.ToInteropValue(sv);
-            Assert.Equal(14, iv);
-        }
+namespace Serilog.Sinks.BrowserConsole.Tests;
 
-        [Fact]
-        public void FormattedScalarsInteropAsStrings()
-        {
-            var sv = new ScalarValue(14);
-            var iv = ObjectModelInterop.ToInteropValue(sv, "000.0");
-            Assert.Equal("014.0", iv);
-        }
+public class ObjectModelInteropTests
+{
+    [Fact]
+    public void ScalarsInteropAsTheirValue()
+    {
+        var sv = new ScalarValue(14);
+        var iv = ObjectModelInterop.ToInteropValue(sv);
+        Assert.Equal(14, iv);
+    }
+
+    [Fact]
+    public void FormattedScalarsInteropAsStrings()
+    {
+        var sv = new ScalarValue(14);
+        var iv = ObjectModelInterop.ToInteropValue(sv, "000.0");
+        Assert.Equal("014.0", iv);
     }
 }

--- a/test/Serilog.Sinks.BrowserConsole.Tests/Serilog.Sinks.BrowserConsole.Tests.csproj
+++ b/test/Serilog.Sinks.BrowserConsole.Tests/Serilog.Sinks.BrowserConsole.Tests.csproj
@@ -1,15 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.9.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This aligns TFMs with `Microsoft.AspNetCore.Components.WebAssembly`, dropping .NET 7 support. As this package can't follow Serilog's core TFM support policy, it's best to version it using a policy consistent with Serilog's ASP.NET Core-related packages.